### PR TITLE
Sort snippets with case-insensitivity

### DIFF
--- a/scripts/builder.js
+++ b/scripts/builder.js
@@ -7,7 +7,19 @@ var staticPartsPath = './static-parts';
 var snippets = {}, startPart = '', endPart = '', output = '';
 
 try {
-  for(var snippet of fs.readdirSync(snippetsPath)){
+  var snippetFilenames = fs.readdirSync(snippetsPath);
+  snippetFilenames.sort((a, b) => {
+    a = a.toLowerCase();
+    b = b.toLowerCase();
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  });
+  for(var snippet of snippetFilenames){
     snippets[snippet] = fs.readFileSync(path.join(snippetsPath,snippet),'utf8');
   }
 }


### PR DESCRIPTION
Running `scripts/builder.js` on different file systems may result in different ordering of the snippets in `README.md` depending on what order the OS returns the array of files in `fs.readFileSync`. Using a custom case-insensitive comparator will ensure consistency when building on different environments.