### PR TITLE
Faster even/odd check with bitwise operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,10 @@ var escapeRegExp = s =>
 
 ### Even or odd number
 
-Use `Math.abs()` to extend logic to negative numbers, check using the modulo (`%`) operator.
 Return `true` if the number is even, `false` if the number is odd.
 
 ```js
-var isEven = num => Math.abs(num) % 2 === 0;
+var isEven = num => (num & 1) === 0;
 ```
 
 ### Factorial


### PR DESCRIPTION
No need to use Math.abs() to extend logic to negative numbers and after that check using the modulo (%) operator.