### PR TITLE
Fix link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,6 @@ You can contribute to **30 seconds of code** by sending pull requests for snippe
 - Snippets must be explained to a certain extent in the description above them. Make sure to include what functions you are using and why.
 - Snippets must solve real-world problems and should be abstract enough to use in different scenarios. This is highly subjective, so send them in anyways.
 - Snippets *should* be written in ES6 if possible.
-- Snippet files must follow the anchor name conventions of (GitHub Flavored Markdown)[https://github.github.com/gfm/], so that the `builder.js` can build the links for the list.
+- Snippet files must follow the anchor name conventions of [GitHub Flavored Markdown](https://github.github.com/gfm/), so that the `builder.js` can build the links for the list.
 - Use the [template](snippet-template.md) to format your snippets.
 - If possible, provide test cases in your Pull Request (link or comment), so that it's easier to verify that each snippet is working. 


### PR DESCRIPTION
Fix the bracket order of the Github Flavored Markdown link in the CONTRIBUTING.md file