### PR TITLE
Refactor measure-time-taken-by-function from spread syntax to callback function

### DIFF
--- a/snippets/measure-time-taken-by-function.md
+++ b/snippets/measure-time-taken-by-function.md
@@ -4,10 +4,10 @@ Use `performance.now()` to get start and end time for the function, `console.log
 First argument is the function name, subsequent arguments are passed to the function.
 
 ```js
-const timeTaken = (func,...args) => {
-  var t0 = performance.now(), r = func(...args);
+const timeTaken = callback => {
+  const t0 = performance.now(), r = callback();
   console.log(performance.now() - t0);
   return r;
 }
-// timeTaken(Math.pow, 2, 10) -> 1024 (0.010000000009313226 logged in console)
+// timeTaken(() => Math.pow(2, 10)) -> 1024 (0.010000000009313226 logged in console)
 ```


### PR DESCRIPTION
I thought the spread syntax was kinda odd, so I opened this pull request to adopt the more common callback style. Discussion welcome.

One potential benefit of this is that the callback can be stored in a separate variable, allowing you to pass the variable to the function timeTaken() directly. You can also pass parameterless functions directly without wrapping them in another arrow function.