### PR TITLE
Make "Anagrams of string" fully functional

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ Base cases are for string `length` equal to `2` or `1`.
 const anagrams = str => {
   if(str.length <= 2)  return str.length === 2 ? [str, str[1] + str[0]] : [str];
   return str.split('').reduce( (acc, letter, i) => {
-    anagrams(str.slice(0, i) + str.slice(i + 1)).map( val => acc.push(letter + val) );
-    return acc;
+    return acc.concat(anagrams(str.slice(0, i) + str.slice(i + 1)).map( val => letter + val ));
   }, []);
 }
 // anagrams('abc') -> ['abc','acb','bac','bca','cab','cba']

--- a/snippets/anagrams-of-string-(with-duplicates).md
+++ b/snippets/anagrams-of-string-(with-duplicates).md
@@ -8,9 +8,8 @@ Base cases are for string `length` equal to `2` or `1`.
 ```js
 const anagrams = str => {
   if(str.length <= 2)  return str.length === 2 ? [str, str[1] + str[0]] : [str];
-  return str.split('').reduce( (acc, letter, i) => {
-    return acc.concat(anagrams(str.slice(0, i) + str.slice(i + 1)).map( val => letter + val ));
-  }, []);
+  return str.split('').reduce( (acc, letter, i) =>
+    acc.concat(anagrams(str.slice(0, i) + str.slice(i + 1)).map( val => letter + val )), []);
 }
 // anagrams('abc') -> ['abc','acb','bac','bca','cab','cba']
 ```

--- a/snippets/anagrams-of-string-(with-duplicates).md
+++ b/snippets/anagrams-of-string-(with-duplicates).md
@@ -9,8 +9,7 @@ Base cases are for string `length` equal to `2` or `1`.
 const anagrams = str => {
   if(str.length <= 2)  return str.length === 2 ? [str, str[1] + str[0]] : [str];
   return str.split('').reduce( (acc, letter, i) => {
-    anagrams(str.slice(0, i) + str.slice(i + 1)).map( val => acc.push(letter + val) );
-    return acc;
+    return acc.concat(anagrams(str.slice(0, i) + str.slice(i + 1)).map( val => letter + val ));
   }, []);
 }
 // anagrams('abc') -> ['abc','acb','bac','bca','cab','cba']


### PR DESCRIPTION
It is good practice to keep map/filter/reduce side-effect free. This PR removes the impure `.push` inside `.map` and instead returns a new array concatenated from the accumulator and the recursive `anagrams` call. 