### PR TITLE
refactor curry to account for variadic functions

### DIFF
--- a/snippets/curry.md
+++ b/snippets/curry.md
@@ -3,6 +3,7 @@
 Use recursion.
 If the number of provided arguments (`args`) is sufficient, call the passed function `f`.
 Otherwise return a curried function `f` that expects the rest of the arguments.
+If you want to curry a function that accepts a variable number of arguments (variadic function) like Math.min for example, you can optionally pass the number of arguments to the second parameter arity.
 
 ```js
 const curry = (f, arity = f.length, next) => 

--- a/snippets/curry.md
+++ b/snippets/curry.md
@@ -5,8 +5,15 @@ If the number of provided arguments (`args`) is sufficient, call the passed func
 Otherwise return a curried function `f` that expects the rest of the arguments.
 
 ```js
-const curry = f =>
-  (...args) =>
-    args.length >= f.length ? f(...args) : (...otherArgs) => curry(f)(...args, ...otherArgs);
+const curry = (f, arity = f.length, next) => 
+  (next = prevArgs => 
+    nextArg => {
+      const args = [ ...prevArgs, nextArg ]
+      return args.length >= arity 
+        ? f(...args)
+        : next(args);
+    }
+  )([]);
 // curry(Math.pow)(2)(10) -> 1024
+// curry(Math.min, 3)(10)(50)(2) -> 2
 ```


### PR DESCRIPTION
altough certainly more verbose, this version accounts for variadic functions such as Math.min that can't represent it's arity with the length property properly. for such cases you can pass the optional argument arity (as in the edited example).
what do you think?