### PR TITLE
Get Ordinal Suffix of Number

### DIFF
--- a/snippets/get-ordinal-suffix-of-number.md
+++ b/snippets/get-ordinal-suffix-of-number.md
@@ -12,7 +12,7 @@ const toOrdinalSuffix = int => {
 	var oPattern = [1,2,3,4];
 	var tPattern = [11, 12, 13, 14, 15, 16, 17, 18, 19]
 
-	return pattern.includes(digits[0]) && !teens.includes(digits[1]) ? int + suffix[digits[0]-1] : int + suffix[3];
+	return oPattern.includes(digits[0]) && !tPattern.includes(digits[1]) ? int + ordinals[digits[0]-1] : int + ordinals[3];
 }
 // toOrdinalSuffix("123") -> "123rd"
 ```

--- a/snippets/get-ordinal-suffix-of-number.md
+++ b/snippets/get-ordinal-suffix-of-number.md
@@ -1,0 +1,18 @@
+### Get Ordinal Suffix of Number
+
+Use the modulo operator (`%`) to find values of single and tens digits.
+Find which ordinal pattern digits match.
+If digit is found in teens pattern, use teens ordinal.
+
+```js
+const toOrdinalSuffix = int => {
+	int = parseInt(int);
+	var digits = [ (int % 10), (int % 100)];
+	var ordinals = ["st", "nd", "rd", "th"];
+	var oPattern = [1,2,3,4];
+	var tPattern = [11, 12, 13, 14, 15, 16, 17, 18, 19]
+
+	return pattern.includes(digits[0]) && !teens.includes(digits[1]) ? int + suffix[digits[0]-1] : int + suffix[3];
+}
+// toOrdinalSuffix("123") -> "123rd"
+```

--- a/snippets/get-ordinal-suffix-of-number.md
+++ b/snippets/get-ordinal-suffix-of-number.md
@@ -5,14 +5,11 @@ Find which ordinal pattern digits match.
 If digit is found in teens pattern, use teens ordinal.
 
 ```js
-const toOrdinalSuffix = int => {
-	int = parseInt(int);
-	var digits = [ (int % 10), (int % 100)];
-	var ordinals = ["st", "nd", "rd", "th"];
-	var oPattern = [1,2,3,4];
-	var tPattern = [11, 12, 13, 14, 15, 16, 17, 18, 19]
-
-	return oPattern.includes(digits[0]) && !tPattern.includes(digits[1]) ? int + ordinals[digits[0]-1] : int + ordinals[3];
+const toOrdinalSuffix = num => {
+  const int = parseInt(num), digits = [(int % 10), (int % 100)],
+    ordinals = ["st", "nd", "rd", "th"], oPattern = [1,2,3,4],
+    tPattern = [11, 12, 13, 14, 15, 16, 17, 18, 19]
+  return oPattern.includes(digits[0]) && !tPattern.includes(digits[1]) ? int + ordinals[digits[0]-1] : int + ordinals[3];
 }
 // toOrdinalSuffix("123") -> "123rd"
 ```


### PR DESCRIPTION
JS Code Snippet to get the ordinal suffix of a given number (int or string).
Returns the provided value wtih concatenated ordinal.
I made it as small as I thought I could to make it easier to read and simply use includes to find pattern matches.