### PR TITLE
Fix: validateNumber: check cooercian

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ Use `!isNaN` in combination with `parseFloat()` to check if the argument is a nu
 Use `isFinite()` to check if the number is finite.
 
 ```js
-const validateNumber = n => !isNaN(parseFloat(n)) && isFinite(n) && Number(n) == n;
+const validateNumber = n => !isNaN(parseFloat(n)) && isFinite(n);
 // validateNumber('10') -> true
 ```
 

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ Use `!isNaN` in combination with `parseFloat()` to check if the argument is a nu
 Use `isFinite()` to check if the number is finite.
 
 ```js
-const validateNumber = n => !isNaN(parseFloat(n)) && isFinite(n);
+const validateNumber = n => !isNaN(parseFloat(n)) && isFinite(n) && Number(n) == n;
 // validateNumber('10') -> true
 ```
 

--- a/snippets/validate-number.md
+++ b/snippets/validate-number.md
@@ -2,6 +2,7 @@
 
 Use `!isNaN` in combination with `parseFloat()` to check if the argument is a number.
 Use `isFinite()` to check if the number is finite.
+Use `Number()` to check if the coercion holds.
 
 ```js
 const validateNumber = n => !isNaN(parseFloat(n)) && isFinite(n);

--- a/snippets/validate-number.md
+++ b/snippets/validate-number.md
@@ -5,6 +5,6 @@ Use `isFinite()` to check if the number is finite.
 Use `Number()` to check if the coercion holds.
 
 ```js
-const validateNumber = n => !isNaN(parseFloat(n)) && isFinite(n);
+const validateNumber = n => !isNaN(parseFloat(n)) && isFinite(n) && Number(n) == n;
 // validateNumber('10') -> true
 ```


### PR DESCRIPTION
now passes all 16 test cases:
```js
[
validateNumber('10') // true
,!validateNumber(false) // false
,!validateNumber(true) // false
,validateNumber(10) // true
,validateNumber(0.10) // true
,validateNumber(010) // true
,validateNumber(0xA) // true
,!validateNumber(NaN) // false
,!validateNumber(null) // false
,!validateNumber(undefined) // false
,!validateNumber('10%') // false, % is a construct
,!validateNumber('10px') // false
,!validateNumber(Infinity) // false
,validateNumber(Math.PI) // true, but is such an extreme edge case...
,validateNumber(0) // true, will probably wreck things
,validatenumber(1e10) // true
]
```