### PR TITLE
Create shallow-clone-object.md

### DIFF
--- a/snippets/shallow-clone-object.md
+++ b/snippets/shallow-clone-object.md
@@ -1,6 +1,6 @@
 ### Shallow clone object
 
-Use the object spread operator to spread the properties of the target object into the clone.
+Use the object `...spread` operator to spread the properties of the target object into the clone.
 
 ```js
 const shallowClone = obj => ({ ...obj });

--- a/snippets/shallow-clone-object.md
+++ b/snippets/shallow-clone-object.md
@@ -1,0 +1,12 @@
+### Shallow clone object
+
+Use the object spread operator to spread the properties of the target object into the clone.
+
+```js
+const shallowClone = obj => ({ ...obj });
+/*
+const a = { x: true, y: 1 };
+const b = shallowClone(a);
+a === b -> false
+*/
+```


### PR DESCRIPTION
We need a deep clone too but that's a different animal.

`JSON.parse(JSON.stringify(obj))` is not very good because it strips functions, etc.