### PR TITLE
Rewrote pipe such that the first function may have any arity.

### DIFF
--- a/snippets/pipe.md
+++ b/snippets/pipe.md
@@ -1,8 +1,18 @@
 ### Pipe
 
-Use `Array.reduce()` to pass value through functions.
+Use `Array.reduce()` to perform left-to-right function composition. The first (leftmost) function can accept one or more arguments; the remaining functions must be unary. 
 
 ```js
-const pipe = (...funcs) => arg => funcs.reduce((acc, func) => func(acc), arg);
-// pipe(btoa, x => x.toUpperCase())("Test") -> "VGVZDA=="
+const pipe = (...fns) => fns.reduce((f, g) => (...args) => g(f(...args)))
+/*
+const add5 = (x) => x + 5
+const multiply = (x, y) => x * y 
+
+const multiplyAndAdd5 = pipe(
+    multiply,
+    add5
+)
+
+multiplyAndAdd5(5, 2) -> 15
+*/
 ```

--- a/snippets/pipe.md
+++ b/snippets/pipe.md
@@ -5,7 +5,7 @@ Use `Array.reduce()` to perform left-to-right function composition. The first (l
 ```js
 const pipe = (...fns) => fns.reduce((f, g) => (...args) => g(f(...args)))
 /*
-const add5 = (x) => x + 5
+const add5 = x => x + 5
 const multiply = (x, y) => x * y 
 
 const multiplyAndAdd5 = pipe(

--- a/snippets/pipe.md
+++ b/snippets/pipe.md
@@ -8,10 +8,7 @@ const pipe = (...fns) => fns.reduce((f, g) => (...args) => g(f(...args)))
 const add5 = x => x + 5
 const multiply = (x, y) => x * y 
 
-const multiplyAndAdd5 = pipe(
-    multiply,
-    add5
-)
+const multiplyAndAdd5 = pipe(multiply, add5)
 
 multiplyAndAdd5(5, 2) -> 15
 */


### PR DESCRIPTION
Now pipe's first function can accept an arbitrary number of arguments; every subsequent function must be unary. The arguments to reduce also use 'f' and 'g', which makes pipe more intuitive to read as it closely resembles its mathematical background. 