### PR TITLE
Create 3DigHexcode-to-6DigHexcode.md

### DIFF
--- a/snippets/3DigHexcode-to-6DigHexcode.md
+++ b/snippets/3DigHexcode-to-6DigHexcode.md
@@ -1,0 +1,12 @@
+### 3DigHexcode to 6DigHexcode
+
+Use `Array.map()` to map the array created by `String.split()` and `Array.join()` to join 
+the mapped array for converting a three-digit RGB notated hexadecimal colorcode to the six-digit form. 
+
+```js
+const convertHex = shortHex => 
+  shortHex[0] == '#' ? ('#' + shortHex.slice(1).split('').map(x => x+x).join('')) : 
+    ('#' + shortHex.split('').map(x => x+x).join(''))
+// convertHex('#03f') -> '#0033ff'
+// convertHex('05a') -> '#0055aa'
+```

--- a/snippets/3DigHexcode-to-6DigHexcode.md
+++ b/snippets/3DigHexcode-to-6DigHexcode.md
@@ -1,12 +1,11 @@
 ### 3DigHexcode to 6DigHexcode
 
-Use `Array.map()` to map the array created by `String.split()` and `Array.join()` to join 
-the mapped array for converting a three-digit RGB notated hexadecimal colorcode to the six-digit form. 
+Use `Array.map()`, `split()` and `Array.join()` to join the mapped array for converting a three-digit RGB notated hexadecimal colorcode to the six-digit form. 
 
 ```js
 const convertHex = shortHex => 
   shortHex[0] == '#' ? ('#' + shortHex.slice(1).split('').map(x => x+x).join('')) : 
-    ('#' + shortHex.split('').map(x => x+x).join(''))
+    ('#' + shortHex.split('').map(x => x+x).join(''));
 // convertHex('#03f') -> '#0033ff'
 // convertHex('05a') -> '#0055aa'
 ```


### PR DESCRIPTION
Snippet for converting three-digit Hex-Colorcodes to six-digit Hex-Colorcodes.

Working proof: [JSFiddle](https://jsfiddle.net/pl4gue/wo0ar550/)