### PR TITLE
Added compose such that the rightmost function may have any arity.

### DIFF
--- a/snippets/array-zip.md
+++ b/snippets/array-zip.md
@@ -6,7 +6,7 @@ If lengths of the argument-arrays vary, `undefined` is used where no value could
 
 ```js
 const zip = (...arrays) => {
-  const maxLength = Math.max.apply(null, arrays.map(a => a.length));
+  const maxLength = Math.max(...arrays.map(x => x.length));
   return Array.from({length: maxLength}).map((_, i) => {
    return Array.from({length: arrays.length}, (_, k) => arrays[k][i]);
   })

--- a/snippets/compose-functions.md
+++ b/snippets/compose-functions.md
@@ -1,4 +1,4 @@
-### Compose
+### Compose functions
 
 Use `Array.reduce()` with the spread operator (`...`) to perform right-to-;eft function composition.
 The last (rightmost) function can accept one or more arguments; the remaining functions must be unary.

--- a/snippets/compose.md
+++ b/snippets/compose.md
@@ -1,0 +1,14 @@
+### Compose
+
+Use `Array.reduce()` with the spread operator (`...`) to perform right-to-;eft function composition.
+The last (rightmost) function can accept one or more arguments; the remaining functions must be unary.
+
+```js
+const compose = (...fns) => fns.reduce((f, g) => (...args) => f(g(...args)));
+/*
+const add5 = x => x + 5
+const multiply = (x, y) => x * y
+const multiplyAndAdd5 = compose(add5, multiply)
+multiplyAndAdd5(5, 2) -> 15
+*/
+```

--- a/snippets/pipe.md
+++ b/snippets/pipe.md
@@ -1,6 +1,6 @@
 ### Pipe
 
-Use `Array.reduce()` to perform left-to-right function composition.
+Use `Array.reduce()` with the spread operator (`...`) to perform left-to-right function composition.
 The first (leftmost) function can accept one or more arguments; the remaining functions must be unary.
 
 ```js


### PR DESCRIPTION
Compose's last (rightmost) function can accept an arbitrary number of arguments; every subsequent function must be unary. The arguments to `Array.reduce()` also use 'f' and 'g', which makes pipe more intuitive to read as it closely resembles its mathematical background.

Also added spread operator into explanation of pipe. 