### PR TITLE
edit Array includes description

### DIFF
--- a/snippets/array-includes.md
+++ b/snippets/array-includes.md
@@ -3,6 +3,7 @@
 Use `slice()` to offset the array/string and `indexOf()` to check if the value is included.
 Omit the last argument, `fromIndex`, to check the whole array/string.
 
+In [ES6](http://www.ecma-international.org/ecma-262/7.0/#sec-array.prototype.includes), you can use a similar native `.includes()` function.
 ```js
 const includes = (collection, val, fromIndex=0) => collection.slice(fromIndex).indexOf(val) != -1;
 // includes("30-seconds-of-code", "code") -> true


### PR DESCRIPTION
there is a function available in ES6 that works like this:
```js
  let arr = [ 1,2,3,4,5,6 ]
  arr.includes(4) // -> true
```
and it also works for strings 
```js
  "30-seconds-of-code".includes("code") // -> true
```
and I think we should avoid native javascript method names like `includes`.
maybe I should add a PR to resolve that issue too.