### PR TITLE
updating array-without.md for more terse implementation and resolving…

### DIFF
--- a/snippets/array-without.md
+++ b/snippets/array-without.md
@@ -1,9 +1,9 @@
 ### Array without
 
-Use `Array.filter()` to create an array excluding all given values.
+Use `Array.filter()` to create an array excluding(using `!Array.includes()`) all given values.
 
 ```js
-const without = (arr, ...args) => arr.filter(v => args.indexOf(v) === -1);
-// without[2, 1, 2, 3], 1, 2) -> [3]
+const without = (arr, ...args) => arr.filter(v => !args.includes(v));
+// without([2, 1, 2, 3], 1, 2) -> [3]
 // without([2, 1, 2, 3, 4, 5, 5, 5, 3, 2, 7, 7], 3, 1, 5, 2) -> [ 4, 7, 7 ]
 ```


### PR DESCRIPTION
… a bug in the comment

a bug in comments(forgotten parentheses) resolved.
and `Array.indexOf() === -1 ` changed to `Array.includes()`