### PR TITLE
Use Boolean for compact

### DIFF
--- a/snippets/compact.md
+++ b/snippets/compact.md
@@ -3,6 +3,6 @@
 Use `Array.filter()` to filter out falsey values (`false`, `null`, `0`, `""`, `undefined`, and `NaN`).
 
 ```js
-const compact = (arr) => arr.filter(v => v);
+const compact = (arr) => arr.filter(Boolean);
 // compact([0, 1, false, 2, '', 3, 'a', 'e'*23, NaN, 's', 34]) -> [ 1, 2, 3, 'a', 's', 34 ]
 ```


### PR DESCRIPTION
Make compact a bit more compact by not creating an arrow function.