### PR TITLE
Fix Array pull (mutates array) to pull out values correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Use `Array.length = 0` to mutate the passed in array by resetting it's length to
 
 ```js
 const pull = (arr, ...args) => {
-  let pulled = arr.filter((v, i) => args.includes(v));
+  let pulled = arr.filter((v, i) => !args.includes(v));
   arr.length = 0; pulled.forEach(v => arr.push(v));
 };
 // let myArray = ['a', 'b', 'c', 'a', 'b', 'c'];

--- a/snippets/array-pull-(mutates-array).md
+++ b/snippets/array-pull-(mutates-array).md
@@ -5,7 +5,7 @@ Use `Array.length = 0` to mutate the passed in array by resetting it's length to
 
 ```js
 const pull = (arr, ...args) => {
-  let pulled = arr.filter((v, i) => args.includes(v));
+  let pulled = arr.filter((v, i) => !args.includes(v));
   arr.length = 0; pulled.forEach(v => arr.push(v));
 };
 // let myArray = ['a', 'b', 'c', 'a', 'b', 'c'];


### PR DESCRIPTION
This PR fixes "Array pull" as it mutates not with pulled values but values we want to pull out.

Before:
```
let myArray = ['a', 'b', 'c', 'a', 'b', 'c'];
pull(myArray, 'a', 'c');
console.log(myArray) -> [ 'a', 'c', 'a', 'c' ];
```

After:
```
let myArray = ['a', 'b', 'c', 'a', 'b', 'c'];
pull(myArray, 'a', 'c');
console.log(myArray) -> [ 'b', 'b' ];
```