### PR TITLE
Fix `nthElement'-example.

### DIFF
--- a/snippets/nthElement.md
+++ b/snippets/nthElement.md
@@ -8,6 +8,6 @@ Omit the second argument, `n`, to get the first element of the array.
 
 ```js
 const nthElement = (arr, n=0) => (n>0? arr.slice(n,n+1) : arr.slice(n))[0];
-// nth(['a','b','c'],1) -> 'b'
-// nth(['a','b','b']-2) -> 'a'
+// nthElement(['a','b','c'],1) -> 'b'
+// nthElement(['a','b','b'],-3) -> 'a'
 ```


### PR DESCRIPTION
I changed the name of the function, inserted a comma and changed the index of the second call to the function, in order for it to give the expected result.