### PR TITLE
Add pullAtIndex

### DIFF
--- a/snippets/pullAtIndex.md
+++ b/snippets/pullAtIndex.md
@@ -1,6 +1,6 @@
 ### pullAtIndex
 
-This method is like pull except that it accepts an array of indexes to filter out before Mutating and pulling all the values from the original array. Which then returns an array of removed elements.
+Mutates the original array to filter out the values at the specified indexes.
 
 Use `Array.filter()` and `Array.includes()` to pull out the values that are not needed.
 Use `Array.length = 0` to mutate the passed in array by resetting it's length to zero and `Array.push()` to re-populate it with only the pulled values.
@@ -11,7 +11,7 @@ const pullAtIndex = (arr, pullArr) => {
   let removed = [];
   let pulled = arr.map((v, i) => pullArr.includes(i) ? removed.push(v) : v)
                   .filter((v, i) => !pullArr.includes(i))
-  arr.length = 0;
+  arr.length = 0; 
   pulled.forEach(v => arr.push(v));
   return removed;
 }

--- a/snippets/pullAtIndex.md
+++ b/snippets/pullAtIndex.md
@@ -1,0 +1,24 @@
+### pullAtIndex
+
+This method is like pull except that it accepts an array of indexes to filter out before Mutating and pulling all the values from the original array. Which then returns an array of removed elements.
+
+Use `Array.filter()` and `Array.includes()` to pull out the values that are not needed.
+Use `Array.length = 0` to mutate the passed in array by resetting it's length to zero and `Array.push()` to re-populate it with only the pulled values.
+Use `Array.push()` to keep track of pulled values 
+
+```js
+const pullAtIndex = (arr, pullArr) => {
+  let removed = [];
+  let pulled = arr.map((v, i) => pullArr.includes(i) ? removed.push(v) : v)
+                  .filter((v, i) => !pullArr.includes(i))
+  arr.length = 0;
+  pulled.forEach(v => arr.push(v));
+  return removed;
+}
+
+// let myArray = ['a', 'b', 'c', 'd'];
+// let pulled = pullAtIndex(myArray, [1, 3]);
+
+// console.log(myArray); -> [ 'a', 'c' ]
+// console.log(pulled); -> [ 'b', 'd' ]
+```

--- a/tag_database
+++ b/tag_database
@@ -71,6 +71,7 @@ pipe:function
 powerset:math
 promisify:function
 pull:array
+pullAtIndex:array
 randomIntegerInRange:math
 randomNumberInRange:math
 readFileLines:node


### PR DESCRIPTION
similar to lodash pullAt method

But I decided to call it pullAtIndex since when using this function before in the past felt weird since the name when compared to using other lodash  `_.pull` method made me assume it was using values. Think having a `pullAtIndex()` which does pull and returns based on index & `pullAtValue()` which does pull and returns based on value would def add value. What do you think @Chalarangelo  

### pullAtIndex

This method is like pull except that it accepts an array of indexes to filter out before Mutating and pulling all the values from the original array. Which then returns an array of removed elements.

Use `Array.filter()` and `Array.includes()` to pull out the values that are not needed.
Use `Array.length = 0` to mutate the passed in array by resetting it's length to zero and `Array.push()` to re-populate it with only the pulled values.
Use `Array.push()` to keep track of pulled values 

```js
const pullAtIndex = (arr, pullArr) => {
  let removed = [];
  let pulled = arr.map((v, i) => pullArr.includes(i) ? removed.push(v) : v)
                  .filter((v, i) => !pullArr.includes(i))
  arr.length = 0;
  pulled.forEach(v => arr.push(v));
  return removed;
}

// let myArray = ['a', 'b', 'c', 'd'];
// let pulled = pullAtIndex(myArray, [1, 3]);

// console.log(myArray); -> [ 'a', 'c' ]
// console.log(pulled); -> [ 'b', 'd' ]
```

https://lodash.com/docs/4.17.4#pullAt