### PR TITLE
fix/update intializeArrayWithRange.md

### DIFF
--- a/snippets/initializeArrayWithRange.md
+++ b/snippets/initializeArrayWithRange.md
@@ -2,7 +2,7 @@
 
 Initializes an array containing the numbers in the specified range where `start` and `end` are inclusive.
 
-Use `Array(end-start)` to create an array of the desired length, `Array.map()` to fill with the desired values in a range.
+Use `Array((end + 1) - start)` to create an array of the desired length, `Array.map()` to fill with the desired values in a range.
 You can omit `start` to use a default value of `0`.
 
 ```js

--- a/snippets/initializeArrayWithRange.md
+++ b/snippets/initializeArrayWithRange.md
@@ -1,12 +1,13 @@
 ### initializeArrayWithRange
 
-Initializes an array containing the numbers in the specified range.
+Initializes an array containing the numbers in the specified range where `start` and `end` are inclusive.
 
 Use `Array(end-start)` to create an array of the desired length, `Array.map()` to fill with the desired values in a range.
 You can omit `start` to use a default value of `0`.
 
 ```js
-const initializeArrayWithRange = (end, start = 0) =>
-  Array.from({ length: end - start }).map((v, i) => i + start);
-// initializeArrayWithRange(5) -> [0,1,2,3,4]
+const initializeArrayWithRange = (end, start = 0) => 
+  Array.from({ length: (end + 1) - start }).map((v, i) => i + start);
+// initializeArrayWithRange(5) -> [0,1,2,3,4,5]
+// initializeArrayWithRange(7, 3) -> [3,4,5,6,7]
 ```


### PR DESCRIPTION
## [BUG] update/fix initializeArrayWithRange

### Expected Snippet Behavior
Behavior should stay consistent. if `start = 0` and `0` gets mapped/initialized I believe `end` should also mapped/initailized like so. If both arguments are inclusive, or inclusive and/or exclusive I think it should say in the description. My assumption however is that the function arguments `start` and `end` are both inclusive 

```js
initializeArrayWithRange(5) //-> [0,1,2,3,4,5]
initializeArrayWithRange(7, 3) //-> [3,4,5,6,7]
```

<!--- If you're suggesting a change/improvement, tell us how it should work -->

### Current Snippet Behavior
However that is not the case and when the arrayRange gets initialized only the start is initialized with the array
```js
const initializeArrayWithRange = (end, start = 0) =>
  Array.from({ length: end - start }).map((v, i) => i + start);
// initializeArrayWithRange(5) -> [0,1,2,3,4]
// initializeArrayWithRange(7, 3) -> [3,4,5,6]
```
<!--- If suggesting a change/improvement, explain the difference from current behavior -->

### Possible Solution
Simple `(end + 1)` fix should do the trick
```js
const initializeArrayWithRange = (end, start = 0) =>
  Array.from({ length: (end + 1) - start }).map((v, i) => i + start);
// initializeArrayWithRange(5) -> [0,1,2,3,4,5]
// initializeArrayWithRange(7, 3) -> [3,4,5,6,7]

```
## *PR fix/Update*
### initializeArrayWithRange

Initializes an array containing the numbers in the specified range where `start` and `end` are inclusive.

Use `Array((end + 1) - start)` to create an array of the desired length, `Array.map()` to fill with the desired values in a range.
You can omit `start` to use a default value of `0`.

```js
const initializeArrayWithRange = (end, start = 0) => 
  Array.from({ length: (end + 1) - start }).map((v, i) => i + start);
// initializeArrayWithRange(5) -> [0,1,2,3,4,5]
// initializeArrayWithRange(7, 3) -> [3,4,5,6,7]
```

As described in #252 
