### PR TITLE
[ENHANCEMENT] Removed unique occurrence of wrapping a single argument function with parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Removes falsey values from an array.
 Use `Array.filter()` to filter out falsey values (`false`, `null`, `0`, `""`, `undefined`, and `NaN`).
 
 ```js
-const compact = (arr) => arr.filter(Boolean);
+const compact = arr => arr.filter(Boolean);
 // compact([0, 1, false, 2, '', 3, 'a', 'e'*23, NaN, 's', 34]) -> [ 1, 2, 3, 'a', 's', 34 ]
 ```
 

--- a/snippets/compact.md
+++ b/snippets/compact.md
@@ -5,6 +5,6 @@ Removes falsey values from an array.
 Use `Array.filter()` to filter out falsey values (`false`, `null`, `0`, `""`, `undefined`, and `NaN`).
 
 ```js
-const compact = (arr) => arr.filter(Boolean);
+const compact = arr => arr.filter(Boolean);
 // compact([0, 1, false, 2, '', 3, 'a', 'e'*23, NaN, 's', 34]) -> [ 1, 2, 3, 'a', 's', 34 ]
 ```


### PR DESCRIPTION
## Description
The Compact snippet was the only example where a single argument of a fat-arrow function was wrapped with a parenthesis.

* [`compact`](#compact)

## What does your PR belong to?
- [ ] Website
- [X] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## [Lodash Backlog](https://github.com/Chalarangelo/30-seconds-of-code/issues/100)
- [ ] I added the prefix [UPDATE: `method.md`] or [ADD: `method.md`]
- [ ] I have referenced the `method` to the lodash backlog.

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have checked that the changes are working properly
- [X] I have checked that there isn't any PR doing the same
- [X] I have read the **CONTRIBUTING** document.
