### PR TITLE
[ENHANCEMENT] Move Promisify to the Adapter category

### DIFF
--- a/tag_database
+++ b/tag_database
@@ -83,7 +83,7 @@ pick:array
 pipe:function
 powerset:math
 primes:math
-promisify:function
+promisify:adapter
 pull:array
 pullAtIndex:array
 pullAtValue:array


### PR DESCRIPTION
## Description
Moves Promisify over to the Adapter category. I have tried ot rebuild but for some reason when I build the Adapter category does not appear

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.