### PR TITLE
[FIX: #355][randomHexColorcode.md] Fix 5-digit issue 

### DIFF
--- a/snippets/randomHexColorCode.md
+++ b/snippets/randomHexColorCode.md
@@ -5,7 +5,11 @@ Generates a random hexadecimal color code.
 Use `Math.random` to generate a random 24-bit(6x4bits) hexadecimal number. Use bit shifting and then convert it to an hexadecimal String using `toString(16)`. 
 
 ```js
-const randomHexColorCode = () => '#'+(Math.random()*0xFFFFFF<<0).toString(16);
+const randomHexColor = () => {
+    let n = (Math.random()*0xfffff|0).toString(16);
+    return '#' + (n.length !== 6
+        ? (Math.random()*0xf|0).toString(16) + n : n);
+}
 // randomHexColorCode() -> "#e34155"
 // randomHexColorCode() -> "#fd73a6"
 // randomHexColorCode() -> "#4144c6"


### PR DESCRIPTION
## Description
The current version has a 1:16 probability of generating a 5-digit colorcode. The edited snippet adds a random hexadecimal digit as prefix in case the generated code is only 5 digits long.
**Resolves** #355

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
