### PR TITLE
Fix documentation for shuffle

### DIFF
--- a/snippets/shuffle.md
+++ b/snippets/shuffle.md
@@ -13,5 +13,7 @@ const shuffle = ([...arr]) => {
   }
   return arr;
 };
-// shuffle([1,2,3]) -> [2,3,1]
+// const foo = [1,2,3]
+// shuffle(foo) -> [2,3,1]
+// console.log(foo) -> [1,2,3]
 ```

--- a/snippets/shuffle.md
+++ b/snippets/shuffle.md
@@ -1,8 +1,8 @@
 ### shuffle
 
-Randomizes the order of the values of an array, in place.
+Randomizes the order of the values of an array, returning a new array.
 
-Uses the Fisher-Yates algoritm to reorder the elements of the array, based on the [Lodash implimentation](https://github.com/lodash/lodash/blob/b2ea6b1cd251796dcb5f9700c4911a7b6223920b/shuffle.js)
+Uses the Fisher-Yates algoritm to reorder the elements of the array, based on the [Lodash implementation](https://github.com/lodash/lodash/blob/b2ea6b1cd251796dcb5f9700c4911a7b6223920b/shuffle.js), but as a pure function.
 
 ```js
 const shuffle = ([...arr]) => {


### PR DESCRIPTION
The implementation of `shuffle` was changed from an in-place function into a pure function, but the documentation was not updated, so I've updated the docs to mention that it returns a new array instead of shuffling the input in place.

Follow-up to https://github.com/Chalarangelo/30-seconds-of-code/pull/358