### PR TITLE
[UPDATE] pluralize.md

### DIFF
--- a/snippets/pluralize.md
+++ b/snippets/pluralize.md
@@ -18,7 +18,7 @@ pluralize(0, 'apple'); // 'apples'
 pluralize(1, 'apple'); // 'apple'
 pluralize(2, 'apple'); // 'apples'
 pluralize(1, 'person'); // 'person'
-pluralize(2, 'person', 'people'); // people
+pluralize(2, 'person', 'people'); // 'people'
 
 const PLURALS = {
   person: 'people',

--- a/snippets/pluralize.md
+++ b/snippets/pluralize.md
@@ -1,23 +1,29 @@
-# pluralize
+### pluralize
 
-If `num` is greater than `1` returns the plural form of the given string, else return the singular form.
+Returns the singular or plural form of the word based on the input number. If the first argument is an `object`, it will use a closure by returning a function that can auto-pluralize plurals that don't simply end in `s` if the supplied dictionary contains the word.
 
-Check if `num` is greater than `0`. Throw an appropriate `Error` if not, return the appropriate string otherwise.
-Omit the third argument, `items`, to use a default plural form same as `item` suffixed with a single `'s'`.
+If `num` is either `-1` or `1`, return the singular form of the word. If `num` is any other number, return the plural form. Omit the third argument to use the default of the singular word + `s`, or supply a custom pluralized word when necessary. If the first argument is an `object`, utilize a closure by returning a function which can use the supplied dictionary to resolve the correct plural form of the word.
 
 ```js
-const pluralize = (num, item, items = item + 's') =>
-  num <= 0
-    ? (() => {
-        throw new Error(`'num' should be >= 1. Value povided was ${num}.`);
-      })()
-    : num === 1 ? item : items;
+const pluralize = (val, word, plural = word + 's') => {
+  const _pluralize = (num, word, plural = word + 's') =>
+    [1, -1].includes(Number(num)) ? word : plural;
+  if (typeof val === 'object') return (num, word) => _pluralize(num, word, val[word]);
+  return _pluralize(val, word, plural);
+};
 ```
 
 ```js
-pluralize(1, 'apple', 'apples'); // 'apple'
-pluralize(3, 'apple', 'apples'); // 'apples'
+pluralize(0, 'apple'); // 'apples'
+pluralize(1, 'apple'); // 'apple'
 pluralize(2, 'apple'); // 'apples'
-pluralize(0, 'apple', 'apples'); // Gives error
-pluralize(-3, 'apple', 'apples'); // Gives error
+pluralize(1, 'person'); // 'person'
+pluralize(2, 'person', 'people'); // people
+
+const PLURALS = {
+  person: 'people',
+  radius: 'radii'
+};
+const autoPluralize = pluralize(PLURALS);
+autoPluralize(2, 'person'); // people
 ```

--- a/snippets/pluralize.md
+++ b/snippets/pluralize.md
@@ -1,6 +1,6 @@
 ### pluralize
 
-Returns the singular or plural form of the word based on the input number. If the first argument is an `object`, it will use a closure by returning a function that can auto-pluralize plurals that don't simply end in `s` if the supplied dictionary contains the word.
+Returns the singular or plural form of the word based on the input number. If the first argument is an `object`, it will use a closure by returning a function that can auto-pluralize words that don't simply end in `s` if the supplied dictionary contains the word.
 
 If `num` is either `-1` or `1`, return the singular form of the word. If `num` is any other number, return the plural form. Omit the third argument to use the default of the singular word + `s`, or supply a custom pluralized word when necessary. If the first argument is an `object`, utilize a closure by returning a function which can use the supplied dictionary to resolve the correct plural form of the word.
 

--- a/snippets/pluralize.md
+++ b/snippets/pluralize.md
@@ -25,5 +25,5 @@ const PLURALS = {
   radius: 'radii'
 };
 const autoPluralize = pluralize(PLURALS);
-autoPluralize(2, 'person'); // people
+autoPluralize(2, 'person'); // 'people'
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Add the prefix [FIX: #(issue number)], [FEATURE] or [ENHANCEMENT] to the Title -->

## Description

- Allows for autopluralization with currying
- Allows any number. `-1` and `1` are considered "singular". Actually should -1 be plural? I don't really know. It doesn't make sense to pluralize negatives, but I feel like it shouldn't throw an error at all. It also coerces strings etc to a number to make life easier.

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
