### PR TITLE
[FIX: #564] Fix inaccurate tomorrow() function

### DIFF
--- a/snippets/tomorrow.md
+++ b/snippets/tomorrow.md
@@ -1,10 +1,20 @@
 ### tomorrow
 
 Results in a string representation of tomorrow's date.
-Use `new Date()` to get today's date, adding `86400000` of seconds to it(24 hours), using `Date.toISOString()` to convert Date object to string.
+Use `new Date()` to get today's date, adding one day using `Date.getDate()` and `Date.setDate()`, and converting the Date object to a string.
 
 ```js
-const tomorrow = () => new Date(new Date().getTime() + 86400000).toISOString().split('T')[0];
+const tomorrow = () => {
+  let t = new Date();
+  t.setDate(t.getDate() + 1);
+  return (
+    t.getFullYear() +
+    '-' +
+    String(t.getMonth() + 1).padStart(2, '0') +
+    '-' +
+    String(t.getDay()).padStart(2, '0')
+  );
+};
 ```
 
 ```js

--- a/snippets/tomorrow.md
+++ b/snippets/tomorrow.md
@@ -7,13 +7,7 @@ Use `new Date()` to get today's date, adding one day using `Date.getDate()` and 
 const tomorrow = () => {
   let t = new Date();
   t.setDate(t.getDate() + 1);
-  return (
-    t.getFullYear() +
-    '-' +
-    String(t.getMonth() + 1).padStart(2, '0') +
-    '-' +
-    String(t.getDate()).padStart(2, '0')
-  );
+  return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}-${String(t.getDate()).padStart(2, '0')}`;
 };
 ```
 

--- a/snippets/tomorrow.md
+++ b/snippets/tomorrow.md
@@ -12,7 +12,7 @@ const tomorrow = () => {
     '-' +
     String(t.getMonth() + 1).padStart(2, '0') +
     '-' +
-    String(t.getDay()).padStart(2, '0')
+    String(t.getDate()).padStart(2, '0')
   );
 };
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Add the prefix [FIX: #(issue number)], [FEATURE] or [ENHANCEMENT] to the Title -->

## Description
Fix a problem due to the assumption that days are always 24 hours long, while due to DST one day a year is 23 hours and one day a year is 25 hours long. This lead this function to give the current date during one hour a year and the day after tomorrow for another hour a year.

Additionally, the function only worked correctly when the user was in the same timezone as UTC. For example in Amsterdam which 1 hour from DST it only worked 23 hours a day. And in Sydney which is 11 hours away from DST, the function only worked correctly for 13 hours each day. During the hours it didn't work correctly it would give the current date instead of tomorrows.

<!--- Describe your changes in detail -->
**Resolves** #564  <!--- Delete if not a issue fix-->

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.