### PR TITLE
[FIX: #580] Fix randomHexColorCode() sometimes returning strings too short & Fix test for same snippet

### DIFF
--- a/snippets/randomHexColorCode.md
+++ b/snippets/randomHexColorCode.md
@@ -6,7 +6,7 @@ Use `Math.random` to generate a random 24-bit(6x4bits) hexadecimal number. Use b
 
 ```js
 const randomHexColorCode = () => {
-  let n = (((Math.random() * 0xfffff)) << 6).toString(16);
+  let n = (((Math.random() * 0xfffff)) * 1000000).toString(16);
   return '#' + n.slice(0, 6);
 };
 ```

--- a/snippets/randomHexColorCode.md
+++ b/snippets/randomHexColorCode.md
@@ -6,7 +6,7 @@ Use `Math.random` to generate a random 24-bit(6x4bits) hexadecimal number. Use b
 
 ```js
 const randomHexColorCode = () => {
-  let n = (((Math.random() * 0xfffff) | 0) << 6).toString(16);
+  let n = (((Math.random() * 0xfffff)) << 6).toString(16);
   return '#' + n.slice(0, 6);
 };
 ```

--- a/snippets/randomHexColorCode.md
+++ b/snippets/randomHexColorCode.md
@@ -6,8 +6,8 @@ Use `Math.random` to generate a random 24-bit(6x4bits) hexadecimal number. Use b
 
 ```js
 const randomHexColorCode = () => {
-  let n = ((Math.random() * 0xfffff) | 0).toString(16);
-  return '#' + (n.length !== 6 ? ((Math.random() * 0xf) | 0).toString(16) + n : n);
+  let n = (((Math.random() * 0xfffff) | 0) << 6).toString(16);
+  return '#' + n.slice(0, 6);
 };
 ```
 

--- a/test/randomHexColorCode/randomHexColorCode.test.js
+++ b/test/randomHexColorCode/randomHexColorCode.test.js
@@ -6,7 +6,7 @@ test('Testing randomHexColorCode', (t) => {
   //Please go to https://github.com/substack/tape
   t.true(typeof randomHexColorCode === 'function', 'randomHexColorCode is a Function');
   //t.deepEqual(randomHexColorCode(args..), 'Expected');
-  //t.equal(randomHexColorCode(args..), 'Expected');
+  t.equal(randomHexColorCode().length, 7);
   //t.false(randomHexColorCode(args..), 'Expected');
   //t.throws(randomHexColorCode(args..), 'Expected');
   t.end();


### PR DESCRIPTION
## Description

Now generating a random number, timesing it by 10^6 and converting it to hex. 

Test previously only checked was of type function, now checks return length is 7 (including `#`)

**Resolves** #580 

## What does your PR belong to?
- [ ] Website
- [X] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [X] Tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have checked that the changes are working properly
- [X] I have checked that there isn't any PR doing the same
- [X] I have read the **CONTRIBUTING** document.
