### PR TITLE
[WEB] Avoid forced reflows inside search function

### DIFF
--- a/static-parts/index-start.html
+++ b/static-parts/index-start.html
@@ -16,7 +16,7 @@
       const search = (node) => {
         let matchingTags = [];
         Array.from(node.parentElement.parentElement.getElementsByTagName('a')).forEach(x => {
-          let data = [x.innerText.toLowerCase(), ...x.getAttribute('tags').split(',')].map(v => !!(v.indexOf(node.value.toLowerCase()) + 1));
+          let data = [x.textContent.toLowerCase(), ...x.getAttribute('tags').split(',')].map(v => !!(v.indexOf(node.value.toLowerCase()) + 1));
           if(data.includes(true)){
             x.style.display = '';
             matchingTags.push(x.getAttribute('tags').split(',')[0]);
@@ -24,7 +24,7 @@
           else x.style.display = 'none';
         });
         Array.from(node.parentElement.parentElement.getElementsByTagName('h3')).forEach(x => {
-          x.style.display = matchingTags.includes(x.innerText.toLowerCase()) ? '' : 'none';
+          x.style.display = matchingTags.includes(x.textContent.toLowerCase()) ? '' : 'none';
         })
       }
       function scrollToTop(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Add the prefix [FIX: #(issue number)], [FEATURE] or [ENHANCEMENT] to the Title -->

## Description
<!--- Describe your changes in detail -->
This PR improves the performance of the snippet search function on the website. The `search` was running slowly (~1 second per `keyup` event) due to forced reflows caused by alternating style reads and writes for each iteration of its internal loops. For example, on each iteration through the loop of snippet nodes, there was a style read due to calling `x.innerText` on a DOM node, then a style write due to `x.style.display = ...`. This forced a reflow on each time through the loop, slowing down the total time taken to search through all nodes for matches. This profile depicts one call of `search` with the argument `"if"` prior to the fix.

![before](https://user-images.githubusercontent.com/12390642/37302278-ac1918ea-25f0-11e8-814a-63761c2665bc.jpeg)

Instead, replacing `x.innerText` with `x.textContent` avoids forced reflows and allows the browser to batch all style updates when the loop finishes. This profile shows the same call to `search` as above, but without the intermediate reflows:

![after](https://user-images.githubusercontent.com/12390642/37302485-4af49ea8-25f1-11e8-99b6-7a6fadbf6283.jpeg)

I found that this change removed the noticeable delay between typing a character and seeing the updated list of results. 

## What does your PR belong to?
- [x] Website
- [ ] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
