### PR TITLE
[FIX:#629] Fix invalid test for sortedLastIndex & Fix sortedLastIndex

### DIFF
--- a/snippets/sortedLastIndex.md
+++ b/snippets/sortedLastIndex.md
@@ -14,5 +14,5 @@ const sortedLastIndex = (arr, n) => {
 ```
 
 ```js
-sortedLastIndex([10, 20, 30, 30, 40], 30); // 3
+sortedLastIndex([10, 20, 30, 30, 40], 30); // 4
 ```

--- a/snippets/sortedLastIndex.md
+++ b/snippets/sortedLastIndex.md
@@ -9,7 +9,7 @@ Use `Array.reverse()` and `Array.findIndex()` to find the appropriate last index
 const sortedLastIndex = (arr, n) => {
   const isDescending = arr[0] > arr[arr.length - 1];
   const index = arr.reverse().findIndex(el => (isDescending ? n <= el : n >= el));
-  return index === -1 ? 0 : arr.length - index - 1;
+  return index === -1 ? 0 : arr.length - index;
 };
 ```
 

--- a/test/sortedLastIndex/sortedLastIndex.js
+++ b/test/sortedLastIndex/sortedLastIndex.js
@@ -1,6 +1,6 @@
 const sortedLastIndex = (arr, n) => {
 const isDescending = arr[0] > arr[arr.length - 1];
 const index = arr.reverse().findIndex(el => (isDescending ? n <= el : n >= el));
-return index === -1 ? 0 : arr.length - index - 1;
+return index === -1 ? 0 : arr.length - index;
 };
 module.exports = sortedLastIndex;

--- a/test/sortedLastIndex/sortedLastIndex.test.js
+++ b/test/sortedLastIndex/sortedLastIndex.test.js
@@ -6,7 +6,7 @@ test('Testing sortedLastIndex', (t) => {
   //Please go to https://github.com/substack/tape
   t.true(typeof sortedLastIndex === 'function', 'sortedLastIndex is a Function');
   t.equal(sortedLastIndex([10, 20, 30, 30, 40], 30), 4, 'Returns the highest index to insert the element without messing up the list order');
-	//t.deepEqual(sortedLastIndex(args..), 'Expected');
+  //t.deepEqual(sortedLastIndex(args..), 'Expected');
   //t.equal(sortedLastIndex(args..), 'Expected');
   //t.false(sortedLastIndex(args..), 'Expected');
   //t.throws(sortedLastIndex(args..), 'Expected');

--- a/test/sortedLastIndex/sortedLastIndex.test.js
+++ b/test/sortedLastIndex/sortedLastIndex.test.js
@@ -5,8 +5,8 @@ test('Testing sortedLastIndex', (t) => {
   //For more information on all the methods supported by tape
   //Please go to https://github.com/substack/tape
   t.true(typeof sortedLastIndex === 'function', 'sortedLastIndex is a Function');
-  t.equal(sortedLastIndex([10, 20, 30, 30, 40], 30), 3, 'Returns the highest index to insert the element without messing up the list order');
-  //t.deepEqual(sortedLastIndex(args..), 'Expected');
+  t.equal(sortedLastIndex([10, 20, 30, 30, 40], 30), 4, 'Returns the highest index to insert the element without messing up the list order');
+	//t.deepEqual(sortedLastIndex(args..), 'Expected');
   //t.equal(sortedLastIndex(args..), 'Expected');
   //t.false(sortedLastIndex(args..), 'Expected');
   //t.throws(sortedLastIndex(args..), 'Expected');


### PR DESCRIPTION

## Description

Change the test of sortedLastIndex to expect a return value of 4 and stopped sortedLastIndex subtracting 1 before returning

**Resolves** #629 

## What does your PR belong to?
- [ ] Website
- [X] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [X] Tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have checked that the changes are working properly
- [X] I have checked that there isn't any PR doing the same
- [X] I have read the **CONTRIBUTING** document.
