### PR TITLE
Add new Clipboard API Disclaimer to copyToClipboard

### DIFF
--- a/snippets/copyToClipboard.md
+++ b/snippets/copyToClipboard.md
@@ -1,6 +1,6 @@
 ### copyToClipboard
 
-> **:warning: This is easily achievable by using the new Async Clipboard Api, which is still experimental by now but should be used in the future instead of this snippet. Find out more about it [here](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard).**
+⚠️ **Notice The same functionality can be easily implemented by using the new asynchronous Clipboard API, which is still experimental but should be used in the future instead of this snippet. Find out more about it [here](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard).**
 
 Copy a string to the clipboard. Only works as a result of user action (i.e. inside a `click` event listener).
 

--- a/snippets/copyToClipboard.md
+++ b/snippets/copyToClipboard.md
@@ -1,6 +1,6 @@
 ### copyToClipboard
 
-⚠️ **Notice The same functionality can be easily implemented by using the new asynchronous Clipboard API, which is still experimental but should be used in the future instead of this snippet. Find out more about it [here](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard).**
+⚠️ **NOTICE **The same functionality can be easily implemented by using the new asynchronous Clipboard API, which is still experimental but should be used in the future instead of this snippet. Find out more about it [here](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard).
 
 Copy a string to the clipboard. Only works as a result of user action (i.e. inside a `click` event listener).
 

--- a/snippets/copyToClipboard.md
+++ b/snippets/copyToClipboard.md
@@ -1,6 +1,6 @@
 ### copyToClipboard
 
-⚠️ **NOTICE **The same functionality can be easily implemented by using the new asynchronous Clipboard API, which is still experimental but should be used in the future instead of this snippet. Find out more about it [here](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard).
+⚠️ **NOTICE:** The same functionality can be easily implemented by using the new asynchronous Clipboard API, which is still experimental but should be used in the future instead of this snippet. Find out more about it [here](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard).
 
 Copy a string to the clipboard. Only works as a result of user action (i.e. inside a `click` event listener).
 

--- a/snippets/copyToClipboard.md
+++ b/snippets/copyToClipboard.md
@@ -1,5 +1,7 @@
 ### copyToClipboard
 
+> **:warning: This is easily achievable by using the new Async Clipboard Api, which is still experimental by now but should be used in the future instead of this snippet. Find out more about it [here](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard).**
+
 Copy a string to the clipboard. Only works as a result of user action (i.e. inside a `click` event listener).
 
 Create a new `<textarea>` element, fill it with the supplied data and add it to the HTML document.


### PR DESCRIPTION
As of now, the Clipboard API is still experimental. But nevertheless, this is how we will be implementing copy&paste&cut in JS in the future. 

https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc#writing-to-the-clipboard

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
