### PR TITLE
Add when()

### DIFF
--- a/snippets/when.md
+++ b/snippets/when.md
@@ -1,7 +1,8 @@
 ### when
 
-Tests a value, `x`, against a predicate function. If `true`, return `fn(x)`. Else, return `x`.
-`when(pred, whenTrue)` returns a function expecting `x` for better composability.
+Tests a value, `x`, against a predicate function. If `true`, return `fn(x)`. Else, return `x`. 
+
+Return a function expecting a single value, `x`, that returns the appropriate value based on `pred`.
 
 ```js
 const when = (pred, whenTrue) => (x) => pred(x) ? whenTrue(x) : x;
@@ -12,7 +13,6 @@ const doubleEvenNumbers = when(
   (x) => x % 2 === 0,
   (x) => x * 2
 );
-
-doubleEvenNumbers(2) // 4
-doubleEvenNumbers(1) // 1
+doubleEvenNumbers(2); // 4
+doubleEvenNumbers(1); // 1
 ```

--- a/snippets/when.md
+++ b/snippets/when.md
@@ -1,7 +1,7 @@
 ### when
 
 Tests a value, `x`, against a predicate function. If `true`, return `fn(x)`. Else, return `x`.
-`when(pred, whenTrue)` returns another function expecting `x` for better composability.
+`when(pred, whenTrue)` returns a function expecting `x` for better composability.
 
 ```js
 const when = (pred, whenTrue) => (x) => pred(x) ? whenTrue(x) : x;

--- a/snippets/when.md
+++ b/snippets/when.md
@@ -1,0 +1,18 @@
+### when
+
+Tests a value, `x`, against a predicate function. If `true`, return `fn(x)`. Else, return `x`.
+`when(pred, whenTrue)` returns another function expecting `x` for better composability.
+
+```js
+const when = (pred, whenTrue) => (x) => pred(x) ? whenTrue(x) : x;
+```
+
+```js
+const doubleEvenNumbers = when(
+  (x) => x % 2 === 0,
+  (x) => x * 2
+);
+
+doubleEvenNumbers(2) // 4
+doubleEvenNumbers(1) // 1
+```

--- a/tag_database
+++ b/tag_database
@@ -291,6 +291,7 @@ URLJoin:string,utility,regexp
 UUIDGeneratorBrowser:browser,utility,random
 UUIDGeneratorNode:node,utility,random
 validateNumber:utility,math
+when:function
 without:array
 words:string,regexp
 xProd:array,math

--- a/test/when/when.js
+++ b/test/when/when.js
@@ -1,0 +1,2 @@
+const when = (pred, whenTrue) => (x) => pred(x) ? whenTrue(x) : x;
+module.exports = when;

--- a/test/when/when.test.js
+++ b/test/when/when.test.js
@@ -1,0 +1,18 @@
+const test = require('tape');
+const when = require('./when.js');
+
+test('Testing when', (t) => {
+  //For more information on all the methods supported by tape
+  //Please go to https://github.com/substack/tape
+  t.true(typeof when === 'function', 'when is a Function');
+
+  const doubleEvenNumbers = when(
+    (x) => x % 2 === 0,
+    (x) => x * 2
+  );
+
+  t.true(doubleEvenNumbers(2) === 4);
+  t.true(doubleEvenNumbers(1) === 1);
+
+  t.end();
+});


### PR DESCRIPTION
Inspired by [Ramda](http://ramdajs.com/docs/#when), I absolutely love this function. It's even better, however, if you compose it by only supplying the first two parameters.

That's why my implementation returns a function expecting `x`.

If accepted, would we consider currying this function? I think the answer's "no" based on [previous discussion](https://github.com/Chalarangelo/30-seconds-of-code/pull/646#issuecomment-380253755) that this is a learning library. 

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement of a snippet)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
