### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "list"
   ],
   "author": "Chalarangelo (chalarangelo@gmail.com)",
-  "license": "MIT",
+  "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/Chalarangelo/30-seconds-of-code/issues"
   },


### PR DESCRIPTION
A while ago we have changed our license from `MIT` to `Creative Commons Zero v1.0 Universal` but we haven't updated our `package.json` file.