### PR TITLE
[ENHANCEMENT] Update palindrome

### DIFF
--- a/snippets/palindrome.md
+++ b/snippets/palindrome.md
@@ -3,7 +3,7 @@
 Returns `true` if the given string is a palindrome, `false` otherwise.
 
 Convert string `String.toLowerCase()` and use `String.replace()` to remove non-alphanumeric characters from it.
-Then, `String.split('')` into individual characters, `Array.reverse()`, `String.join('')` and compare to the original, unreversed string, after converting it `String.tolowerCase()`.
+Then, use the spread operator (`...`) to split string into individual characters, `Array.reverse()`, `String.join('')` and compare to the original, unreversed string, after converting it `String.tolowerCase()`.
 
 ```js
 const palindrome = str => {

--- a/snippets/palindrome.md
+++ b/snippets/palindrome.md
@@ -8,13 +8,7 @@ Then, `String.split('')` into individual characters, `Array.reverse()`, `String.
 ```js
 const palindrome = str => {
   const s = str.toLowerCase().replace(/[\W_]/g, '');
-  return (
-    s ===
-    s
-      .split('')
-      .reverse()
-      .join('')
-  );
+  return s === [...s].reverse().join('');
 };
 ```
 

--- a/test/palindrome/palindrome.js
+++ b/test/palindrome/palindrome.js
@@ -1,11 +1,5 @@
 const palindrome = str => {
 const s = str.toLowerCase().replace(/[\W_]/g, '');
-return (
-s ===
-s
-.split('')
-.reverse()
-.join('')
-);
+return s === [...s].reverse().join('');
 };
 module.exports = palindrome;

--- a/test/testlog
+++ b/test/testlog
@@ -1,6 +1,6 @@
-Test log for: Wed Apr 25 2018 21:00:18 GMT+0000 (UTC)
+Test log for: Thu Apr 26 2018 19:20:53 GMT+0200 (CEST)
 
-> 30-seconds-of-code@0.0.3 test /home/travis/build/Chalarangelo/30-seconds-of-code
+> 30-seconds-of-code@0.0.3 test /Users/stefanfejes/Projects/30-seconds-of-code
 > tape test/**/*.test.js | tap-spec
 
 
@@ -982,7 +982,7 @@ Test log for: Wed Apr 25 2018 21:00:18 GMT+0000 (UTC)
   Testing isTravisCI
 
     ✔ isTravisCI is a Function
-    ✔ Running on Travis, correctly evaluates
+    ✔ Not running on Travis, correctly evaluates
 
   Testing isTypedArray
 
@@ -1724,9 +1724,25 @@ Test log for: Wed Apr 25 2018 21:00:18 GMT+0000 (UTC)
   Testing toCurrency
 
     ✔ toCurrency is a Function
-    ✔ currency: Euro | currencyLangFormat: Local
+
+    ✖ currency: Euro | currencyLangFormat: Local
+    ---------------------------------------------
+      operator: equal
+      expected: '€ 123,456.79'
+      actual:   '€123,456.79'
+      at: Test.test (/Users/stefanfejes/Projects/30-seconds-of-code/test/toCurrency/toCurrency.test.js:8:5)
+      stack: |-
+
     ✔ currency: US Dollar | currencyLangFormat: English (United States)
-    ✔ currency: Japanese Yen | currencyLangFormat: Local
+
+    ✖ currency: Japanese Yen | currencyLangFormat: Local
+    -----------------------------------------------------
+      operator: equal
+      expected: 'JP¥ 322,342,436,423'
+      actual:   '¥322,342,436,423'
+      at: Test.test (/Users/stefanfejes/Projects/30-seconds-of-code/test/toCurrency/toCurrency.test.js:11:5)
+      stack: |-
+
 
   Testing toDecimalMark
 
@@ -1995,13 +2011,24 @@ Test log for: Wed Apr 25 2018 21:00:18 GMT+0000 (UTC)
     ✔ Sends a GET request
     ✔ Runs the function provided
     ✔ Runs promises in series
-    ✔ Works as expecting, passing arguments properly
     ✔ Sends a POST request
+    ✔ Works as expecting, passing arguments properly
     ✔ Works with multiple promises
 
 
+
+  Failed Tests: There were 2 failures
+
+    Testing toCurrency
+
+      ✖ currency: Euro | currencyLangFormat: Local
+      ✖ currency: Japanese Yen | currencyLangFormat: Local
+
+
   total:     1014
-  passing:   1014
-  duration:  2.3s
+  passing:   1012
+  failing:   2
+  duration:  2.4s
 
 
+undefined


### PR DESCRIPTION
## Description
Currently, `palindrome` snippet doesn't use the same syntax as `reverseString`. I've updated palindrome's description as well as code to match more modern ES6ish syntax that `reverseString` uses. 

Ran tests, everything is fine. Nothing is broken 😉 

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
