### PR TITLE
Add reject

### DIFF
--- a/snippets/reject.md
+++ b/snippets/reject.md
@@ -1,0 +1,15 @@
+### reject
+
+Takes a predicate and array, like `Array.filter()`, but only keeps `x` if `pred(x) === false`.
+
+```js
+const reject = (pred, array) => array.filter((...args) => !pred(...args))
+```
+
+```js
+reject(x => x % 2 === 0, [1, 2, 3, 4, 5])
+// [1, 3, 5]
+
+reject(word => word.length > 4, ['Apple', 'Pear', 'Kiwi', 'Banana'])
+// ['Pear', 'Kiwi']
+```

--- a/snippets/reject.md
+++ b/snippets/reject.md
@@ -3,13 +3,10 @@
 Takes a predicate and array, like `Array.filter()`, but only keeps `x` if `pred(x) === false`.
 
 ```js
-const reject = (pred, array) => array.filter((...args) => !pred(...args))
+const reject = (pred, array) => array.filter((...args) => !pred(...args));
 ```
 
 ```js
-reject(x => x % 2 === 0, [1, 2, 3, 4, 5])
-// [1, 3, 5]
-
-reject(word => word.length > 4, ['Apple', 'Pear', 'Kiwi', 'Banana'])
-// ['Pear', 'Kiwi']
+reject(x => x % 2 === 0, [1, 2, 3, 4, 5]); // [1, 3, 5]
+reject(word => word.length > 4, ['Apple', 'Pear', 'Kiwi', 'Banana']); // ['Pear', 'Kiwi']
 ```

--- a/tag_database
+++ b/tag_database
@@ -217,6 +217,7 @@ redirect:browser,url
 reducedFilter:array
 reduceSuccessive:array,function
 reduceWhich:array,function
+reject:array
 remove:array
 removeNonASCII:string,regexp
 renameKeys:object

--- a/test/reject/reject.js
+++ b/test/reject/reject.js
@@ -1,0 +1,2 @@
+const reject = (pred, array) => array.filter((...args) => !pred(...args))
+module.exports = reject;

--- a/test/reject/reject.js
+++ b/test/reject/reject.js
@@ -1,2 +1,2 @@
-const reject = (pred, array) => array.filter((...args) => !pred(...args))
+const reject = (pred, array) => array.filter((...args) => !pred(...args));
 module.exports = reject;

--- a/test/reject/reject.test.js
+++ b/test/reject/reject.test.js
@@ -1,0 +1,24 @@
+const test = require('tape');
+const reject = require('./reject.js');
+
+test('Testing reject', (t) => {
+  //For more information on all the methods supported by tape
+  //Please go to https://github.com/substack/tape
+  t.true(typeof reject === 'function', 'reject is a Function');
+
+  const noEvens = reject(
+    (x) => x % 2 === 0,
+    [1, 2, 3, 4, 5]
+  );
+
+  t.deepEqual(noEvens, [1, 3, 5]);
+
+  const fourLettersOrLess = reject(
+    (word) => word.length > 4,
+    ['Apple', 'Pear', 'Kiwi', 'Banana']
+  );
+
+  t.deepEqual(fourLettersOrLess, ['Pear', 'Kiwi']);
+
+  t.end();
+});


### PR DESCRIPTION
`Array.filter`'s complement. Whatever `filter` keeps, `reject` denies.

This repo's a great functional programming resource, but I surprisingly haven't encountered complementary functions yet. Maybe I haven't look hard enough, but it'd still be cool to contribute this 😁 .

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement of a snippet)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
