### PR TITLE
Simplify findLast snippet

### DIFF
--- a/snippets/findLast.md
+++ b/snippets/findLast.md
@@ -2,7 +2,7 @@
 
 Returns the last element for which the provided function returns a truthy value.
 
-Use `Array.filter()` to remove elements for which `fn` returns falsey values, `Array.slice(-1)` to get the last one.
+Use `Array.filter()` to remove elements for which `fn` returns falsey values, `Array.pop()` to get the last one.
 
 ```js
 const findLast = (arr, fn) => arr.filter(fn).slice(-1)[0];

--- a/snippets/findLast.md
+++ b/snippets/findLast.md
@@ -5,7 +5,7 @@ Returns the last element for which the provided function returns a truthy value.
 Use `Array.filter()` to remove elements for which `fn` returns falsey values, `Array.pop()` to get the last one.
 
 ```js
-const findLast = (arr, fn) => arr.filter(fn).slice(-1)[0];
+const findLast = (arr, fn) => arr.filter(fn).pop();
 ```
 
 ```js

--- a/test/findLast/findLast.js
+++ b/test/findLast/findLast.js
@@ -1,2 +1,2 @@
-const findLast = (arr, fn) => arr.filter(fn).slice(-1)[0];
+const findLast = (arr, fn) => arr.filter(fn).pop();
 module.exports = findLast;


### PR DESCRIPTION
Simplify findLast snippet [ENHANCEMENT]

## Description
Use native metho pop of array instead slicing and getting the last element.

## What does your PR belong to?
- [ ] Website
- [X] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have checked that the changes are working properly
- [X] I have checked that there isn't any PR doing the same
- [X] I have read the **CONTRIBUTING** document.
