### PR TITLE
Simplify findLastIndex

### DIFF
--- a/snippets/findLastIndex.md
+++ b/snippets/findLastIndex.md
@@ -3,14 +3,14 @@
 Returns the index of the last element for which the provided function returns a truthy value.
 
 Use `Array.map()` to map each element to an array with its index and value.
-Use `Array.filter()` to remove elements for which `fn` returns falsey values, `Array.slice(-1)` to get the last one.
+Use `Array.filter()` to remove elements for which `fn` returns falsey values, `Array.pop()` to get the last one.
 
 ```js
 const findLastIndex = (arr, fn) =>
   arr
     .map((val, i) => [i, val])
-    .filter(val => fn(val[1], val[0], arr))
-    .slice(-1)[0][0];
+    .filter(([i, val]) => fn(val, i, arr))
+    .pop()[0];
 ```
 
 ```js

--- a/test/findLastIndex/findLastIndex.js
+++ b/test/findLastIndex/findLastIndex.js
@@ -1,6 +1,6 @@
 const findLastIndex = (arr, fn) =>
 arr
 .map((val, i) => [i, val])
-.filter(val => fn(val[1], val[0], arr))
-.slice(-1)[0][0];
+.filter(([i, val]) => fn(val, i, arr))
+.pop()[0];
 module.exports = findLastIndex;


### PR DESCRIPTION
Simplify findLastIndex [ENHANCEMENT]

## Description
Use native method pop of array instead slicing and getting the last element also destructuring elements inside filter method.

## What does your PR belong to?
- [ ] Website
- [X] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have checked that the changes are working properly
- [X] I have checked that there isn't any PR doing the same
- [X] I have read the **CONTRIBUTING** document.
