### PR TITLE
Using more declarative way to create array in nodeListToArray

### DIFF
--- a/snippets/nodeListToArray.md
+++ b/snippets/nodeListToArray.md
@@ -2,7 +2,7 @@
 
 Converts a `NodeList` to an array.
 
-Use `Array.prototype.slice()` and `Function.prototype.call()` to convert a `NodeList` to an array.
+Use spread operator inside new array to convert a `NodeList` to an array.
 
 ```js
 const nodeListToArray = nodeList => [...nodeList];

--- a/snippets/nodeListToArray.md
+++ b/snippets/nodeListToArray.md
@@ -5,7 +5,7 @@ Converts a `NodeList` to an array.
 Use `Array.prototype.slice()` and `Function.prototype.call()` to convert a `NodeList` to an array.
 
 ```js
-const nodeListToArray = nodeList => Array.prototype.slice.call(nodeList);
+const nodeListToArray = nodeList => [...nodeList];
 ```
 
 ```js

--- a/test/nodeListToArray/nodeListToArray.js
+++ b/test/nodeListToArray/nodeListToArray.js
@@ -1,2 +1,2 @@
-const nodeListToArray = nodeList => Array.prototype.slice.call(nodeList);
+const nodeListToArray = nodeList => [...nodeList];
 module.exports = nodeListToArray;


### PR DESCRIPTION
Simplify nodeListToArray [ENHANCEMENT]

Spread operator is more declarative that Array.prototype.slice (with confusing Function.prototype.call) and modern.

## What does your PR belong to?
- [ ] Website
- [X] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have checked that the changes are working properly
- [X] I have checked that there isn't any PR doing the same
- [X] I have read the **CONTRIBUTING** document.