### PR TITLE
Fix RGBtoHSB edge-cases returning NaN

### DIFF
--- a/snippets/RGBToHSB.md
+++ b/snippets/RGBToHSB.md
@@ -19,7 +19,7 @@ const RGBToHSB = (r, g, b) => {
   const v = Math.max(r, g, b),
     n = v - Math.min(r, g, b);
   const h =
-    n === 0 ? 0 : n && v === r ? (g - b) / n : v === g ? 2 + (b - r) / n : 4 + (r - g) / n
+    n === 0 ? 0 : n && v === r ? (g - b) / n : v === g ? 2 + (b - r) / n : 4 + (r - g) / n;
   return [60 * (h < 0 ? h + 6 : h), v && (n / v) * 100, v * 100];
 };
 ```


### PR DESCRIPTION
I changed the line that finds the value of h so that if n is 0, the value of h becomes simply 0.
This prevents the part of the equation from being 0 divided by 0 that causes the NaN value to be produced.

Closes issue #1849 