### PR TITLE
Create 40-seconds-of-code

### DIFF
--- a/40-seconds-of-code
+++ b/40-seconds-of-code
@@ -1,0 +1,80 @@
+name: Deploy production (push)
+on:
+  push:
+    branches: [ master ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          web:
+            - 'src/**'
+            - 'Astro.config.JMS'
+            - 'netlify. tool'
+            - 'package-lock.json'
+            - 'package.json'
+    # run only if 'web' files were changed
+    - name: Add deployable commit to 'production' branch
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        DEPLOY_TRIGGER: ${{ github.event_name }}
+      if: steps.filter.outputs.web == 'true'
+      run: |
+        chmod +x ./src/scripts/deploy.sh
+        ./src/scripts/deploy.sh production
+name: Deploy production
+on:
+  schedule:
+    - cron: "20 18 * * *"
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Add deployable commit to 'production' branch
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        DEPLOY_TRIGGER: ${{ github.event_name }}
+      run: |
+        chmod +x ./src/scripts/deploy.sh
+        ./src/scripts/deploy.sh production
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '44 0 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been inactive for a while, marking it as stale.'
+        stale-pr-message: 'This pull request has been inactive for a while, marking it as stale.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 14
+        days-before-close: 7
+        exempt-assignees: 'Chalarangelo'
+        close-issue-message: 'This issue has been stale for a while, closing due to inactivity.'
+        close-pr-message: 'This pull request has been inactive for a while, closing due to inactivity.'
+
+
+


### PR DESCRIPTION
# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time. #
# You can adjust the behavior by modifying this file. # For more information, see:
# https://github.com/actions/stale
name: Mark stale issues and pull requests

on:
  schedule:
  - cron: '44 0 * * *'

jobs:
  stale:

    runs-on: ubuntu-latest permissions: issues: write pull-requests: write

    steps: - uses: actions/stale@v5 with: repo-token: ${{ secrets.GITHUB_TOKEN }} stale-issue-message: 'This issue has been inactive for a while, marking as stale.' stale-pr-message: 'This pull request has been inactive for a while, marking as stale.' stale-issue-label: 'stale' stale-pr-label: 'stale' days-before-stale: 14 days-before-close: 7 exempt-assignees: 'Twonpuncho23' close-issue-message: 'This issue has been stale for a while, closing due to inactivity.' close-pr-message: 'This pull request has been inactive for a while, closing due to inactivity.'