### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/Chalarangelo/30-seconds-of-code/security/code-scanning/24](https://github.com/Chalarangelo/30-seconds-of-code/security/code-scanning/24)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only needs to read the repository contents (e.g., for checking out the code), we will set `contents: read` as the minimal required permission. This block will be added at the root level of the workflow, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
